### PR TITLE
Enable go test in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,5 @@ script:
   - set -e
   - go get -u golang.org/x/lint/golint
   - python3 -m venv venv && source venv/bin/activate && pip install pre-commit && pre-commit run -a
-  - go build ./...
-  - echo "skip go test since alisa server is not available in public network"
+  - go test -v .
 


### PR DESCRIPTION
Enable go test in TravisCI by default. Tests that require POP server should skip as

https://github.com/sql-machine-learning/goalisa/blob/160202beb1765882939346d521fad0cec59d61fe/alisa_wrap_test.go#L24-L27