### PR TITLE
Parse `curr_project` from dsn

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -24,7 +24,7 @@ import (
 func TestOpen(t *testing.T) {
 	a := assert.New(t)
 	d := &Driver{}
-	conn, err := d.Open(fmt.Sprintf("pop_access_id:pop_access_key@pop_url?env=%s", base64.URLEncoding.EncodeToString([]byte(`{"value1": "param1"}`))))
+	conn, err := d.Open(fmt.Sprintf("pop_access_id:pop_access_key@pop_url?curr_project=proj&env=%s", base64.URLEncoding.EncodeToString([]byte(`{"value1": "param1"}`))))
 	a.NoError(err)
 	a.NotNil(conn)
 }

--- a/dsn.go
+++ b/dsn.go
@@ -39,6 +39,8 @@ type Config struct {
 	Env map[string]string
 	// verbose denotes whether to print logs to the terminal
 	Verbose bool
+	// Project(name) of Alisa, generated from Env.
+	Project string
 }
 
 // ParseDSN deserialize the connect string
@@ -54,7 +56,7 @@ func ParseDSN(dsn string) (*Config, error) {
 		return nil, err
 	}
 
-	requiredParameter := []string{"env"}
+	requiredParameter := []string{"env", "curr_project"}
 	for _, k := range requiredParameter {
 		v := kvs.Get(k)
 		if v == "" {
@@ -67,12 +69,10 @@ func ParseDSN(dsn string) (*Config, error) {
 		return nil, err
 	}
 
-	verbose := false
-	if kvs.Get("verbose") == "true" {
-		verbose = true
-	}
+	verbose := kvs.Get("verbose") == "true"
+	project := kvs.Get("curr_project")
 
-	return &Config{POPAccessID: pid, POPAccessSecret: ps, POPURL: purl, Env: env, Verbose: verbose}, nil
+	return &Config{POPAccessID: pid, POPAccessSecret: ps, POPURL: purl, Env: env, Verbose: verbose, Project: project}, nil
 }
 
 func encodeEnv(env map[string]string) string {
@@ -107,7 +107,7 @@ func decodeEnv(b64env string) (map[string]string, error) {
 
 // FormatDSN serialize a config to connect string
 func (cfg *Config) FormatDSN() string {
-	return fmt.Sprintf(`%s:%s@%s?env=%s&verbose=%s`,
+	return fmt.Sprintf(`%s:%s@%s?env=%s&verbose=%s&curr_project=%s`,
 		cfg.POPAccessID, cfg.POPAccessSecret, cfg.POPURL,
-		encodeEnv(cfg.Env), strconv.FormatBool(cfg.Verbose))
+		encodeEnv(cfg.Env), strconv.FormatBool(cfg.Verbose), cfg.Project)
 }


### PR DESCRIPTION
Although the `curr_project` is generated like this:
https://github.com/sql-machine-learning/goalisa/blob/9457ffd1a28e8671f3c1f1027eabfba61458cd25/dsn_test.go#L99-L102
We parse it from the `dsn`.