### PR TITLE
Use unpadded base64 encoding for DSN

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -24,7 +24,7 @@ import (
 func TestOpen(t *testing.T) {
 	a := assert.New(t)
 	d := &Driver{}
-	conn, err := d.Open(fmt.Sprintf("pop_access_id:pop_access_key@pop_url?curr_project=proj&env=%s", base64.URLEncoding.EncodeToString([]byte(`{"value1": "param1"}`))))
+	conn, err := d.Open(fmt.Sprintf("pop_access_id:pop_access_key@pop_url?curr_project=proj&env=%s", base64.RawURLEncoding.EncodeToString([]byte(`{"value1": "param1"}`))))
 	a.NoError(err)
 	a.NotNil(conn)
 }

--- a/dsn.go
+++ b/dsn.go
@@ -88,13 +88,13 @@ func encodeEnv(env map[string]string) string {
 		kvStrs = append(kvStrs, fmt.Sprintf(`"%s":"%s"`, k, env[k]))
 	}
 	jsonStr := `{` + strings.Join(kvStrs, `,`) + `}`
-	return base64.URLEncoding.EncodeToString([]byte(jsonStr))
+	return base64.RawURLEncoding.EncodeToString([]byte(jsonStr))
 }
 
 func decodeEnv(b64env string) (map[string]string, error) {
 	// NOTE(tony): we use url.ParseQuery to parse parameters in ParseDSN,
 	// so we use URL-compatible base64 format.
-	buf, err := base64.URLEncoding.DecodeString(b64env)
+	buf, err := base64.RawURLEncoding.DecodeString(b64env)
 	if err != nil {
 		return nil, err
 	}

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var b64EnvStr = base64.URLEncoding.EncodeToString([]byte(`{"param1":"value1"}`))
+var b64EnvStr = base64.RawURLEncoding.EncodeToString([]byte(`{"param1":"value1"}`))
 
 func TestEncodeEnv(t *testing.T) {
 	a := assert.New(t)


### PR DESCRIPTION
By padding `=` at the end of the string, base64 encoding enforces the encoded string length to be dividable by 4. The padded `=` is error-prone since we use `=` to assign parameters.

So we disable the padding by calling RawURLEncoding following [this suggesetion](https://stackoverflow.com/a/59158279).